### PR TITLE
Update education links

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
       <a target="_blank" href="https://www.eosocal.io/">EOSoCal</a>
       <a target="_blank" href="https://eoscannon.io">EOS Cannon</a>
     </div>
-    <a target="_blank" class="educational-material" href="https://github.com/EOS-Nation/Scholar-Testnet">
+    <a target="_blank" class="educational-material" href="https://github.com/ScholarTestnet">
       Educational material
     </a>
   </div>

--- a/map.html
+++ b/map.html
@@ -19,7 +19,7 @@
     <a target="_blank" href="https://www.eosocal.io/">EOSoCal</a>
     <a target="_blank" href="https://eoscannon.io">EOS Cannon</a>
   </div>
-  <a target="_blank" class="educational-material" href="https://github.com/EOS-Nation/Scholar-Testnet">
+  <a target="_blank" class="educational-material" href="https://github.com/ScholarTestnet">
     Educational material
   </a>
 </div>


### PR DESCRIPTION
Links updated to take visitors to our Scholar Net organization instead of being redirected from the previous Scholar Net repo to the server configuration.